### PR TITLE
Add spinner support to calculators

### DIFF
--- a/assets/css/framework.css
+++ b/assets/css/framework.css
@@ -1,5 +1,6 @@
 /* Общие стили для контейнера калькулятора */
 .cf-calculator__container {
+    position: relative;
     display: flex;
     flex-wrap: wrap;
     gap: 30px;
@@ -483,4 +484,36 @@
     color: #666;
     margin-top: 20px;
     line-height: 1.5;
+}
+
+/* Spinner */
+.cf-preloader {
+    display: none;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255, 255, 255, 0.8);
+    z-index: 1000;
+}
+
+.cf-preloader::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 40px;
+    height: 40px;
+    margin-top: -20px;
+    margin-left: -20px;
+    border: 4px solid #3C57EA;
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: cf-spin 1s linear infinite;
+}
+
+@keyframes cf-spin {
+    from { transform: rotate(0deg); }
+    to { transform: rotate(360deg); }
 }

--- a/assets/js/framework.js
+++ b/assets/js/framework.js
@@ -302,11 +302,14 @@ jQuery(document).ready(function($) {
         data.action = 'cf_calculate';
         data.nonce = cfAjax.nonce;
 
+        container.find('.cf-preloader').show();
+
         $.ajax({
             url: cfAjax.ajaxurl,
             type: 'POST',
             data: data,
             success: function(response) {
+                container.find('.cf-preloader').hide();
                 console.log('AJAX Success:', response);
                 if (response.success) {
                     const result = response.data;
@@ -317,6 +320,7 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function(xhr, status, error) {
+                container.find('.cf-preloader').hide();
                 console.log('AJAX Error:', status, error);
                 alert(cfAjax.translations.ajax_error);
             }

--- a/modules/compound-interest/frontend.php
+++ b/modules/compound-interest/frontend.php
@@ -77,5 +77,6 @@ if ($enabled) : ?>
                 </table>
             </div>
         </div>
+        <div class="cf-preloader"></div>
     </div>
 </div>

--- a/modules/deposit/frontend.php
+++ b/modules/deposit/frontend.php
@@ -187,5 +187,6 @@ if ($enabled) : ?>
                 </table>
             </div>
         </div>
+        <div class="cf-preloader"></div>
     </div>
 </div>

--- a/modules/goals/frontend.php
+++ b/modules/goals/frontend.php
@@ -101,6 +101,7 @@ if ($enabled) : ?>
             <?php _e('With this calculator, you can calculate how much money you need to invest or save to achieve any financial goal by a specific date.', 'calculator-framework'); ?>
         </p>
     </div>
+    <div class="cf-preloader"></div>
 </div>
     </div>
 </div>

--- a/modules/loan/frontend.php
+++ b/modules/loan/frontend.php
@@ -55,4 +55,5 @@ if ($enabled) : ?>
             <tbody></tbody>
         </table>
     </div>
+    <div class="cf-preloader"></div>
 </div>

--- a/modules/savings/frontend.php
+++ b/modules/savings/frontend.php
@@ -76,5 +76,6 @@ if ($enabled) : ?>
                 </table>
             </div>
         </div>
+        <div class="cf-preloader"></div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- add hidden spinner markup to each calculator template
- style spinner overlay in CSS
- show and hide spinner while AJAX requests run

## Testing
- `php -l modules/compound-interest/frontend.php`
- `php -l modules/deposit/frontend.php`
- `php -l modules/goals/frontend.php`
- `php -l modules/loan/frontend.php`
- `php -l modules/savings/frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_687baf60c7b08328a965559e574315e3