### PR TITLE
Load html2canvas and jsPDF from CDN

### DIFF
--- a/calculator-framework.php
+++ b/calculator-framework.php
@@ -46,7 +46,13 @@ add_action('plugins_loaded', 'cf_init');
 
 // Add defer attribute to specific scripts
 function cf_add_defer_attribute($tag, $handle) {
-    if (in_array($handle, ['chart-js', 'cf-framework-js'])) {
+    $defer_scripts = [
+        'chart-js',
+        'html2canvas',
+        'jspdf',
+        'cf-framework-js',
+    ];
+    if (in_array($handle, $defer_scripts, true)) {
         return str_replace(' src', ' defer="defer" src', $tag);
     }
     return $tag;

--- a/includes/class-calculator-framework.php
+++ b/includes/class-calculator-framework.php
@@ -34,7 +34,21 @@ class Calculator_Framework {
             error_log('Enqueuing assets for calculator');
             wp_enqueue_script('jquery');
             wp_enqueue_script('chart-js', CF_PLUGIN_URL . 'vendor/chart.js', array(), '4.4.0', true);
-            wp_enqueue_script('cf-framework-js', CF_PLUGIN_URL . 'assets/js/framework.js', array('jquery', 'chart-js'), '1.0.0', true);
+            wp_enqueue_script(
+                'html2canvas',
+                'https://unpkg.com/html2canvas@1.4.1/dist/html2canvas.min.js',
+                array(),
+                '1.4.1',
+                true
+            );
+            wp_enqueue_script(
+                'jspdf',
+                'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+                array(),
+                '2.5.1',
+                true
+            );
+            wp_enqueue_script('cf-framework-js', CF_PLUGIN_URL . 'assets/js/framework.js', array('jquery', 'chart-js', 'html2canvas', 'jspdf'), '1.0.0', true);
             wp_localize_script('cf-framework-js', 'cfAjax', array(
                 'ajaxurl' => admin_url('admin-ajax.php'),
                 'nonce' => wp_create_nonce('cf_calculate_nonce'),


### PR DESCRIPTION
## Summary
- load html2canvas and jsPDF from CDN instead of local files
- defer loading of new CDN scripts

## Testing
- `php -l includes/class-calculator-framework.php`
- `php -l calculator-framework.php`
- `find . -name '*.php' -print0 | xargs -0 -n1 php -l`

------
https://chatgpt.com/codex/tasks/task_e_687bbb6f370483288d3bde18e9eb0bca